### PR TITLE
Update gtest dependency

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-gtest/1.8.0@bincrafters/stable
+gtest/1.8.1@bincrafters/stable
 
 [options]
 gtest:shared=False


### PR DESCRIPTION
Running ./scripts/build.sh failed so I looked up gtest and it seems like the latest release is 1.8.1. This fixed it. Not sure why they're not supporting older versions anymore.