### PR TITLE
Fix incorrect implementation of SM2 algorithm

### DIFF
--- a/common/src/flashcardGrader.cpp
+++ b/common/src/flashcardGrader.cpp
@@ -21,7 +21,7 @@ auto FlashcardGrader::gradeFlashcard(
             default:
                 auto newInterval = static_cast<unsigned int>(
                         std::round(
-                                static_cast<float>(flashcard.interval) - 1 * flashcard.easinessFactor
+                                static_cast<float>(flashcard.interval) * flashcard.easinessFactor
                         )
                 );
                 flashcard.interval = newInterval;

--- a/common/test/test_gradeFlashcard.cpp
+++ b/common/test/test_gradeFlashcard.cpp
@@ -155,7 +155,7 @@ TEST(gradeFlashcard, long_repetition_grade_5_response) {
     unsigned long long october_23_2016 = 1477207892;
 
     unsigned int oneDay = 86400;
-    unsigned long long october_27_2016 = october_23_2016 + (oneDay * 4);
+    unsigned long long november_7_2016 = october_23_2016 + (oneDay * 15);
 
     float expectedEasinessFactor = 2.6;
 
@@ -170,8 +170,8 @@ TEST(gradeFlashcard, long_repetition_grade_5_response) {
 
 
     EXPECT_EQ(gradedCard.repetition, 7);
-    EXPECT_EQ(gradedCard.interval, 4);
+    EXPECT_EQ(gradedCard.interval, 15);
     EXPECT_EQ(gradedCard.easinessFactor, expectedEasinessFactor);
     EXPECT_EQ(gradedCard.previousDate, october_23_2016);
-    EXPECT_EQ(gradedCard.nextDate, october_27_2016);
+    EXPECT_EQ(gradedCard.nextDate, november_7_2016);
 }

--- a/platforms/typescript/src/__tests__/gradeFlashcard.test.ts
+++ b/platforms/typescript/src/__tests__/gradeFlashcard.test.ts
@@ -170,7 +170,7 @@ describe("gradeFlashcard", () => {
 
   it("should grade a flashcard with a very easy rating and a long history", async () => {
     const october_23_2016 = 1477207892;
-    const october_27_2016 = 1477553492;
+    const november_7_2016 = 1478503892;
 
     const flashcard: FlashcardWrapper = {
       repetition: 6,
@@ -189,10 +189,10 @@ describe("gradeFlashcard", () => {
 
     const expectedGradedFlashcard: FlashcardWrapper = {
       repetition: 7,
-      interval: 4,
+      interval: 15,
       easinessFactor: 2.5, // this is off of the expected output by 0.1 - it's probably due to a minor loss of floating point precision between emscripten and JS
       previousDate: october_23_2016,
-      nextDate: october_27_2016,
+      nextDate: november_7_2016,
     };
 
     actualGradedFlashcard.easinessFactor =

--- a/platforms/xcode/LibSpaceyTests/FlashcardGraderTests.swift
+++ b/platforms/xcode/LibSpaceyTests/FlashcardGraderTests.swift
@@ -124,8 +124,8 @@ class LibSpaceyTests: XCTestCase {
 
     func test_flashcardGrader_grade_long_repetition() {
 
-        let october_23_2016 = 1477207892;
-        let october_27_2016 = 1477553492;
+        let october_23_2016 = 1477207892
+        let november_7_2016 = 1478503892
 
         let flashcardWrapper = FlashcardWrapper()
         flashcardWrapper.interval = 6
@@ -136,9 +136,9 @@ class LibSpaceyTests: XCTestCase {
         let gradedFlashcardWrapper = FlashcardWrapperGrader.gradeFlashcardWrapper(flashcardWrapper, grade: Grade.VeryEasy, currentDate: Date(timeIntervalSince1970: TimeInterval(october_23_2016)))
 
         XCTAssertEqual(gradedFlashcardWrapper?.repetition, 7)
-        XCTAssertEqual(gradedFlashcardWrapper?.interval, 4)
+        XCTAssertEqual(gradedFlashcardWrapper?.interval, 15)
         XCTAssertEqual(gradedFlashcardWrapper?.easinessFactor, 2.6)
         XCTAssertEqual(gradedFlashcardWrapper?.previousDate, Date(timeIntervalSince1970: TimeInterval(october_23_2016)))
-        XCTAssertEqual(gradedFlashcardWrapper?.nextDate, Date(timeIntervalSince1970: TimeInterval(october_27_2016)))
+        XCTAssertEqual(gradedFlashcardWrapper?.nextDate, Date(timeIntervalSince1970: TimeInterval(november_7_2016)))
     }
 }


### PR DESCRIPTION
Interval should increase after receiving grade 5 (perfect recall of flashcard). At the moment it decreases. This addresses problem two in this issue:

https://github.com/walterscarborough/LibSpacey/issues/1